### PR TITLE
gradle  8버전 업데이트

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("runewords.android.application.compose")
     id("runewords.android.application.firebase")
     id("runewords.android.hilt")
-    id("org.jlleitschuh.gradle.ktlint")
     id("runewords.android.dependency.guard")
     id("com.google.firebase.appdistribution")
 }

--- a/app/src/main/java/com/beok/runewords/RuneWordsActivity.kt
+++ b/app/src/main/java/com/beok/runewords/RuneWordsActivity.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.beok.runewords.home.BuildConfig
-import com.beok.runewords.home.R
 import com.beok.runewords.inapp.presentation.InAppUpdateState
 import com.beok.runewords.inapp.presentation.InAppUpdateViewModel
 import com.beok.runewords.navigation.RuneWordsNavHost
@@ -59,9 +57,9 @@ internal class RuneWordsActivity : ComponentActivity() {
             this,
             getString(
                 if (BuildConfig.DEBUG) {
-                    R.string.test_admob_screen_app_key
+                    com.beok.runewords.common.R.string.test_admob_screen_app_key
                 } else {
-                    R.string.admob_screen_app_key
+                    com.beok.runewords.common.R.string.admob_screen_app_key
                 }
             ),
             AdRequest.Builder().build(),

--- a/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
@@ -27,6 +27,10 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
                         excludes += "META-INF/LICENSE-notice.md"
                     }
                 }
+
+                buildFeatures {
+                    buildConfig = true
+                }
             }
         }
     }

--- a/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
@@ -21,7 +21,7 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
                     versionName = VERSION_NAME
                 }
 
-                packagingOptions {
+                packaging {
                     resources {
                         excludes += "META-INF/LICENSE.md"
                         excludes += "META-INF/LICENSE-notice.md"

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/GradleManagedDevices.kt
@@ -34,7 +34,7 @@ private data class DeviceConfig(
     val systemImageSource: String
 ) {
     val taskName: String
-        get() = device.toLowerCase(Locale.getDefault())
+        get() = device.lowercase(Locale.getDefault())
             .replace(oldValue = " ", newValue = "")
             .plus(other = "api")
             .plus(other = apiLevel.toString())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,17 +4,6 @@ buildscript {
         mavenCentral()
         maven("https://plugins.gradle.org/m2/")
     }
-    dependencies {
-        classpath(libs.gradle)
-        classpath(libs.kotlin.gradle)
-        classpath(libs.android.junit5.gradle)
-        classpath(libs.google.services.gradle)
-        classpath(libs.hilt.android.gradle)
-        classpath(libs.firebase.crashlytics.gradle)
-        classpath(libs.ktlint.gradle)
-        classpath(libs.dependency.guard)
-        classpath(libs.firebase.appdistribution.gradle)
-    }
 }
 
 subprojects {
@@ -23,4 +12,16 @@ subprojects {
     repositories {
         mavenCentral()
     }
+}
+
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.android.junit5) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.dependency.guard) apply false
+    alias(libs.plugins.appdistribution) apply false
 }

--- a/feature/detail/src/main/java/com/beok/runewords/detail/presentation/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/beok/runewords/detail/presentation/DetailScreen.kt
@@ -125,7 +125,9 @@ private fun DetailContent(
                             deviceCurrentWidth
                         )
                     )
-                    adUnitId = context.getString(R.string.admob_banner_app_key)
+                    adUnitId = context.getString(
+                        com.beok.runewords.common.R.string.admob_banner_app_key
+                    )
                     loadAd(AdRequest.Builder().build())
                 }
             }

--- a/feature/info/src/main/java/com/beok/runewords/info/presentation/RuneInfoScreen.kt
+++ b/feature/info/src/main/java/com/beok/runewords/info/presentation/RuneInfoScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.beok.runewords.common.model.Rune
-import com.beok.runewords.info.R
+import com.beok.runewords.common.R
 
 @Composable
 internal fun RuneInfoScreen(rune: Rune?) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ hilt = "2.46"
 coroutines = "1.7.0"
 flipper = "0.190.0"
 kotlin = "1.8.10"
+gradle = "8.0.2"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version = "1.7.0" }
@@ -50,7 +51,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 # Gradle
-gradle = { module = "com.android.tools.build:gradle", version = "8.0.2" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 android-junit5-gradle = { module = "de.mannodermaus.gradle.plugins:android-junit5", version = "1.8.2.0" }
 google-services-gradle = { module = "com.google.gms:google-services", version = "4.3.14" }
@@ -69,6 +70,17 @@ junit = { module = "androidx.test.ext:junit", version = "1.1.5" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.5.1" }
 uiautomator = { module = "androidx.test.uiautomator:uiautomator", version = "2.2.0" }
 benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version = "1.1.1" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "gradle" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+android-junit5 = { id = "de.mannodermaus.android-junit5", version = "1.8.2.0" }
+google-services = { id = "com.google.gms.google-services", version = "4.3.14" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "2.8.1" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "11.0.0" }
+dependency-guard = { id = "com.dropbox.dependency-guard", version = "0.4.3" }
+appdistribution = { id = "com.google.firebase.appdistribution", version = "4.0.0" }
 
 [bundles]
 compose = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,13 +53,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 # Gradle
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-android-junit5-gradle = { module = "de.mannodermaus.gradle.plugins:android-junit5", version = "1.8.2.0" }
-google-services-gradle = { module = "com.google.gms:google-services", version = "4.3.14" }
-hilt-android-gradle = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
-firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version = "2.8.1" }
-ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "11.0.0" }
 dependency-guard = { module = "com.dropbox.dependency-guard:dependency-guard", version = "0.4.3" }
-firebase-appdistribution-gradle = { module = "com.google.firebase:firebase-appdistribution-gradle", version = "4.0.0" }
 
 # Flipper
 flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,11 +15,12 @@ play-services-ads = { module = "com.google.android.gms:play-services-ads", versi
 play-core-ktx = { module = "com.google.android.play:core-ktx", version = "1.8.1" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version = "0.3.5" }
 
-# JUnit5
+# Test
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jUnit5" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jUnit5" }
 assertj-core = { module = "org.assertj:assertj-core", version = "3.22.0" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+mockk = { module = "io.mockk:mockk", version = "1.12.3" }
 
 # Compose
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
@@ -48,10 +49,6 @@ hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", ve
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
-mockk = { module = "io.mockk:mockk", version = "1.12.3" }
-
-profile-installer = { module = "androidx.profileinstaller:profileinstaller", version = "1.2.0" }
-
 # Gradle
 gradle = { module = "com.android.tools.build:gradle", version = "8.0.2" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -67,7 +64,7 @@ firebase-appdistribution-gradle = { module = "com.google.firebase:firebase-appdi
 flipper = { module = "com.facebook.flipper:flipper", version.ref = "flipper" }
 soloader = { module = "com.facebook.soloader:soloader", version = "0.10.4" }
 
-#
+# Benchmark
 junit = { module = "androidx.test.ext:junit", version = "1.1.5" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version = "3.5.1" }
 uiautomator = { module = "androidx.test.uiautomator:uiautomator", version = "2.2.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ mockk = { module = "io.mockk:mockk", version = "1.12.3" }
 profile-installer = { module = "androidx.profileinstaller:profileinstaller", version = "1.2.0" }
 
 # Gradle
-gradle = { module = "com.android.tools.build:gradle", version = "7.4.2" }
+gradle = { module = "com.android.tools.build:gradle", version = "8.0.2" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 android-junit5-gradle = { module = "de.mannodermaus.gradle.plugins:android-junit5", version = "1.8.2.0" }
 google-services-gradle = { module = "com.google.gms:google-services", version = "4.3.14" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Wed Oct 05 22:34:11 KST 2022
+#Sat Jun 24 20:24:10 KST 2023
 distributionBase=GRADLE_USER_HOME
-distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=ff7bf6a86f09b9b2c40bb8f48b25fc19cf2b2664fd1d220cd7ab833ec758d0d7
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
### 업데이트로 인한 이슈들
- ktlint가 동작하지 않음 (아직 java11만 지원하는듯)
  - https://github.com/JLLeitschuh/ktlint-gradle/issues/668
  - https://github.com/JLLeitschuh/ktlint-gradle/issues/677
- plugins의 alias에 빨간줄 표시
  - 빨간줄 표시는 뜨지만 빌드는 잘 됨
  - 8.1 버전에서 수정된 것으로 보임
    - https://github.com/gradle/gradle/issues/22797
### 업데이트로 인한 변경점
  - packaingOptions -> packaging
  - `android.nonTransitiveRClass` 옵션의 기본값이 true
  - BuildConfig 파일을 생성하려면 옵션을 주어야 함