### PR TITLE
gradle 8.1 적용

### DIFF
--- a/.github/workflows/firebase_app_distributor.yml
+++ b/.github/workflows/firebase_app_distributor.yml
@@ -22,10 +22,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/play_store.yml
+++ b/.github/workflows/play_store.yml
@@ -22,10 +22,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,10 +25,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           gradle: cache
 

--- a/app/src/main/java/com/beok/runewords/RuneWordsActivity.kt
+++ b/app/src/main/java/com/beok/runewords/RuneWordsActivity.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.beok.runewords.home.BuildConfig
-import com.beok.runewords.home.R
 import com.beok.runewords.inapp.presentation.InAppUpdateState
 import com.beok.runewords.inapp.presentation.InAppUpdateViewModel
 import com.beok.runewords.navigation.RuneWordsNavHost
@@ -66,9 +65,9 @@ internal class RuneWordsActivity : ComponentActivity() {
                     this@RuneWordsActivity,
                     getString(
                         if (BuildConfig.DEBUG) {
-                            R.string.test_admob_screen_app_key
+                            com.beok.runewords.common.R.string.test_admob_screen_app_key
                         } else {
-                            R.string.admob_screen_app_key
+                            com.beok.runewords.common.R.string.admob_screen_app_key
                         }
                     ),
                     AdRequest.Builder().build(),

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 group = "com.beok.runewords.buildlogic"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationConventionPlugin.kt
@@ -21,7 +21,7 @@ internal class AndroidApplicationConventionPlugin : Plugin<Project> {
                     versionName = VERSION_NAME
                 }
 
-                packagingOptions {
+                packaging {
                     resources {
                         excludes += "META-INF/LICENSE.md"
                         excludes += "META-INF/LICENSE-notice.md"

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/AndroidCompose.kt
@@ -8,7 +8,7 @@ import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 
 internal fun Project.configureAndroidCompose(
-    commonExtension: CommonExtension<*, *, *, *>
+    commonExtension: CommonExtension<*, *, *, *, *>
 ) {
     val libs = extensions.getByType<VersionCatalogsExtension>()
         .named("libs")

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/AndroidCompose.kt
@@ -15,6 +15,7 @@ internal fun Project.configureAndroidCompose(
 
     commonExtension.run {
         buildFeatures {
+            buildConfig = true
             compose = true
         }
 

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/GradleManagedDevices.kt
@@ -34,7 +34,7 @@ private data class DeviceConfig(
     val systemImageSource: String
 ) {
     val taskName: String
-        get() = device.toLowerCase(Locale.getDefault())
+        get() = device.lowercase(Locale.getDefault())
             .replace(oldValue = " ", newValue = "")
             .plus(other = "Api")
             .plus(other = apiLevel.toString())

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/GradleManagedDevices.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/GradleManagedDevices.kt
@@ -7,7 +7,7 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.invoke
 
 internal fun configureGradleManagedDevices(
-    commonExtension: CommonExtension<*, *, *, *>
+    commonExtension: CommonExtension<*, *, *, *, *>
 ) {
     val pixel2 = DeviceConfig(
         device = "Pixel 2",

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/JaCoCo.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/JaCoCo.kt
@@ -4,6 +4,7 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.tasks.testing.Test
+import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
@@ -57,10 +58,10 @@ internal fun Project.configureJacoco(
     val jacocoTestReport = tasks.create("jacocoTestReport")
 
     androidComponentsExtension.onVariants { variant ->
-        val testTaskName = "test${variant.name.capitalize()}UnitTest"
+        val testTaskName = "test${variant.name.capitalized()}UnitTest"
 
         val reportTask =
-            tasks.register("jacoco${testTaskName.capitalize()}Report", JacocoReport::class) {
+            tasks.register("jacoco${testTaskName.capitalized()}Report", JacocoReport::class) {
                 dependsOn(testTaskName)
 
                 reports {

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/KotlinAndroid.kt
@@ -17,44 +17,42 @@ internal fun Project.configureKotlinAndroid(
         }
 
         compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
 
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_11.toString()
+        tasks.withType<KotlinCompile>().configureEach {
+            kotlinOptions {
+                jvmTarget = JavaVersion.VERSION_17.toString()
 
-            freeCompilerArgs = freeCompilerArgs
-                .plus(listOf("-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"))
-            freeCompilerArgs = freeCompilerArgs
-                .plus(
-                    listOf(
-                        "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
-                        "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
-                    )
-                )
-            if (project.findProperty("enableMultiModuleComposeReports") == "true") {
+                freeCompilerArgs = freeCompilerArgs
+                    .plus(listOf("-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"))
                 freeCompilerArgs = freeCompilerArgs
                     .plus(
                         listOf(
-                            "-P",
-                            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                                    "${rootProject.buildDir.absolutePath}/compose_metrics/"
+                            "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                            "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi"
                         )
                     )
-                freeCompilerArgs = freeCompilerArgs
-                    .plus(
-                        listOf(
-                            "-P",
-                            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                                    "${rootProject.buildDir.absolutePath}/compose_metrics/"
+                if (project.findProperty("enableMultiModuleComposeReports") == "true") {
+                    freeCompilerArgs = freeCompilerArgs
+                        .plus(
+                            listOf(
+                                "-P",
+                                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                                        "${rootProject.buildDir.absolutePath}/compose_metrics/"
+                            )
                         )
-                    )
+                    freeCompilerArgs = freeCompilerArgs
+                        .plus(
+                            listOf(
+                                "-P",
+                                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                                        "${rootProject.buildDir.absolutePath}/compose_metrics/"
+                            )
+                        )
+                }
             }
         }
     }
-}
-
-private fun CommonExtension<*, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) {
-    (this as ExtensionAware).extensions.configure("kotlinOptions", block)
 }

--- a/build-logic/convention/src/main/java/com/beok/runewords/convention/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/com/beok/runewords/convention/KotlinAndroid.kt
@@ -3,11 +3,11 @@ package com.beok.runewords.convention
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureKotlinAndroid(
-    commonExtension: CommonExtension<*, *, *, *>
+    commonExtension: CommonExtension<*, *, *, *, *>
 ) {
     commonExtension.run {
         compileSdk = 33

--- a/feature/detail/src/main/java/com/beok/runewords/detail/presentation/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/beok/runewords/detail/presentation/DetailScreen.kt
@@ -129,7 +129,9 @@ private fun DetailContent(
                             deviceCurrentWidth
                         )
                     )
-                    adUnitId = context.getString(R.string.admob_banner_app_key)
+                    adUnitId = context.getString(
+                        com.beok.runewords.common.R.string.admob_banner_app_key
+                    )
                     loadAd(AdRequest.Builder().build())
                 }
             }

--- a/feature/info/src/main/java/com/beok/runewords/info/presentation/RuneInfoScreen.kt
+++ b/feature/info/src/main/java/com/beok/runewords/info/presentation/RuneInfoScreen.kt
@@ -53,26 +53,26 @@ private fun RuneInfoContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 24.dp),
-            imageResourceID = R.drawable.ic_weapon,
+            imageResourceID = com.beok.runewords.common.R.drawable.ic_weapon,
             messageResourceID = rune.weaponResourceID
         )
         RuneInfoItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 24.dp),
-            imageResourceID = R.drawable.ic_helm,
+            imageResourceID = com.beok.runewords.common.R.drawable.ic_helm,
             messageResourceID = rune.helmResourceID
         )
         RuneInfoItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 24.dp),
-            imageResourceID = R.drawable.ic_armor,
+            imageResourceID = com.beok.runewords.common.R.drawable.ic_armor,
             messageResourceID = rune.armorResourceID
         )
         RuneInfoItem(
             modifier = Modifier.fillMaxWidth(),
-            imageResourceID = R.drawable.ic_shield,
+            imageResourceID = com.beok.runewords.common.R.drawable.ic_shield,
             messageResourceID = rune.shieldResourceID
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ hilt = "2.47"
 coroutines = "1.7.3"
 flipper = "0.190.0"
 kotlin = "1.8.22"
-gradle = "7.4.2"
+gradle = "8.1.1"
 jacoco = "0.8.7"
 room = "2.5.2"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Wed Oct 05 22:34:11 KST 2022
+#Sun Sep 10 00:10:29 KST 2023
 distributionBase=GRADLE_USER_HOME
-distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=a62c5f99585dd9e1f95dab7b9415a0e698fa9dd1e6c38537faa81ac078f4d23e
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
### 작업 내용
https://github.com/BeokBeok/RuneWords/pull/157 의 연장선

### 8.1 버전으로 설정한 이유
<img width="632" alt="스크린샷 2023-09-10 오전 12 57 51" src="https://github.com/BeokBeok/RuneWords/assets/48344355/ba13f72d-feb2-43ca-9c90-ba67bb047c4d">

- 현재 안드로이드 스튜디오 stable 버전은 **Giraffe** 이고, AGP(AndroidGradlePlugin) 버전이 **8.1**로 명시되어 있음
- ref. https://developer.android.com/build/releases/gradle-plugin#android_gradle_plugin_and_android_studio_compatibility


<br class="Apple-interchange-newline">

### 터미널에 `./gradlew` 명령어가 동작하지 않는 이유
#### 원인
<img width="562" alt="스크린샷 2023-09-10 오전 12 55 11" src="https://github.com/BeokBeok/RuneWords/assets/48344355/4935215b-9dde-46d4-8215-369c10a3bd31">

- gradle 버전이 8.1이지만, JVM 버전은 11임
- JVM 버전이 17이어야만 gradlew 명령어가 동작함

#### 대책
- gradlew 명령어 입력 시 JVM 경로를 지정하면 동작됨
  - ./gradlew **-Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home** ktlintformat