### PR TITLE
:arrow_up: Bump ksp from 1.9.10-1.0.13 to 1.9.20-1.0.14

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "1.9.10"
 gradle = "8.1.2"
 jacoco = "0.8.7"
 room = "2.6.0-rc01"
-ksp = "1.9.10-1.0.13"
+ksp = "1.9.20-1.0.14"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version = "1.12.0" }


### PR DESCRIPTION
Bumps `ksp` from 1.9.10-1.0.13 to 1.9.20-1.0.14.

Updates `com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin` from 1.9.10-1.0.13 to 1.9.20-1.0.14
- [Release notes](https://github.com/google/ksp/releases)
- [Commits](https://github.com/google/ksp/compare/1.9.10-1.0.13...1.9.20-1.0.14)

Updates `com.google.devtools.ksp` from 1.9.10-1.0.13 to 1.9.20-1.0.14
- [Release notes](https://github.com/google/ksp/releases)
- [Commits](https://github.com/google/ksp/compare/1.9.10-1.0.13...1.9.20-1.0.14)

---
updated-dependencies:
- dependency-name: com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.google.devtools.ksp dependency-type: direct:production update-type: version-update:semver-patch ...