### PR TITLE
태그 포맷([0-9]+.[0-9]+.[0-9]+)에 맞는 태그 푸시 시에만 Play Store 배포 워크플로우가 동작하도록 수정합니다.

### DIFF
--- a/.github/workflows/play_store.yml
+++ b/.github/workflows/play_store.yml
@@ -2,7 +2,8 @@ name: Play Store
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/play_store.yml
+++ b/.github/workflows/play_store.yml
@@ -3,7 +3,7 @@ name: Play Store
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:


### PR DESCRIPTION
## 개요
- Play Store 배포 워크플로우(`play_store.yml`)가 리모트 태그 형식(`[0-9]+.[0-9]+.[0-9]+` 포맷)과 일치하는 태그가 푸시될 때만 동작하도록 트리거 조건을 수정합니다.

## 변경 사항
- `.github/workflows/play_store.yml`: `tags: [ '[0-9]+.[0-9]+.[0-9]+' ]`로 변경하여 `MAJOR.MINOR.PATCH` 형식(예: `3.2.0`, `1.10.0`)의 태그가 발행 및 푸시될 때만 배포가 진행되도록 설정